### PR TITLE
Added basic model framework

### DIFF
--- a/pyro/model.py
+++ b/pyro/model.py
@@ -1,0 +1,151 @@
+import torch
+import os
+import pathlib
+from typing import Union, Iterable
+from functools import reduce
+from datetime import datetime
+
+LENGTH = 50
+
+
+class Model(torch.nn.Module):
+    """
+    Extensible layer on top of `torch.nn.Module` to add amenities such as
+    - Object-oriented model checkpointing
+    - Verbose model summary (TensorFlow style)
+    Note: Only top level modules should extend this class - all other submodules should style defer to `torch.nn.Module`.
+    """
+
+    def __init__(self, checkpoint_dir: Union[str, os.PathLike], *args, **kwargs):
+        """
+        Initialize the Model object.
+
+        Args:
+            checkpoint_dir (Union[str, os.PathLike]): The directory path where checkpoints will be saved.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+        """
+        super(Model, self).__init__(*args, **kwargs)
+        if isinstance(checkpoint_dir, str):
+            self.checkpoint_dir = pathlib.Path(checkpoint_dir)
+        else:
+            self.checkpoint_dir = checkpoint_dir
+
+    def save(self, name: str = None, **metadata):
+        """
+        Save model parameters and metadata to file. Checkpoint is saved as "{name}.pth"
+
+        Args:
+            name (str, optional): Name of model checkpoint. Defaults to current timestamp.
+        """
+        if not self.checkpoint_dir.exists():
+            self.checkpoint_dir.mkdir(parents=True)
+
+        if name is None:
+            name = datetime.now().strftime("%m-%d-%y_%H-%M-%S") + ".pth"
+
+        # create the state dictionary
+        state = {
+            "name": name,
+            "state_dict": self.state_dict(),
+        }
+        for key in metadata:
+            state[key] = metadata[key]
+        filename = self.checkpoint_dir / name
+        torch.save(state, filename)
+
+    def load(self, device: str = "cpu", name: str = None):
+        """
+        Load model parameters from file.
+
+        Model parameters are stored internally to model and metadata stored at runtime is returned to user.
+
+        Args:
+            device (str, optional): Device to load parameters to. Defaults to "cpu".
+            id (str, optional): Name of the model checkpoint to load from checkpoint
+                                directory. If unspecified, loads the most recent model (by timestamp).
+
+        Returns:
+            dict: Metadata associated with checkpoint
+        """
+        if name is None:
+            try:
+                file = find_file_by_timestamp(self.checkpoint_dir.iterdir())
+            except TypeError:  # occurs when iterable to reduce is empty
+                raise RuntimeError(
+                    "Could not load checkpoint: checkpoint directory empty"
+                )
+        else:
+            file = self.checkpoint_dir / name
+
+        with file.open("rb") as ifstream:
+            checkpoint = torch.load(ifstream, map_location=device)
+
+        try:
+            self.load_state_dict(checkpoint["state_dict"])
+        except KeyError:
+            raise RuntimeError(
+                'Invalid checkpoint file: could not find key "state_dict"'
+            )
+
+        return checkpoint
+
+    def summary(self) -> str:
+        """
+        Return a summary of the model, including the number of parameters.
+
+        Returns:
+            str: A string representation of the model summary.
+        """
+        output = []
+        total_param, trainable_param = 0, 0
+
+        separator = "\n" + "─" * LENGTH + "\n"
+        thick_separator = "=" * LENGTH
+
+        def extract(input):
+            nonlocal total_param, trainable_param
+            name, module = input
+            count = sum(map(lambda x: x.numel(), module.parameters()))
+            total_param += count
+            if module.requires_grad_:
+                trainable_param += count
+            return f"{name}: {module} - {count} parameters"
+
+        output.append(f"{self.__class__.__name__}:")
+        output.append(thick_separator)
+        output.append(separator.join(map(extract, self.named_children())))
+        output.append(thick_separator)
+        output.append(
+            f"Total: {total_param} parameters\n"
+            f"Trainable: {trainable_param} parameters ({(trainable_param / total_param * 100):.2f}% trainable)"
+        )
+        output.append(thick_separator)
+
+        return "\n".join(output)
+
+    def __repr__(self):
+        return self.summary()
+
+
+# --- utils ---
+
+
+def find_file_by_timestamp(files: Iterable[pathlib.Path], latest=True) -> pathlib.Path:
+    """
+    Find the file with the latest or earliest timestamp among the given files.
+
+    Args:
+        files (Iterable[pathlib.Path]): A collection of pathlib.Path objects representing the files to search.
+        latest (bool, optional): If True, find the file with the latest timestamp. If False, find the file with the earliest timestamp. Defaults to True.
+
+    Returns:
+        pathlib.Path: The path of the file with the latest or earliest timestamp.
+    """
+    cmp = lambda t1, t2: t1 > t2 if latest else t2 < t1
+    reducer = (
+        lambda file1, file2: file1
+        if cmp(file1.stat().st_mtime_ns, file2.stat().st_mtime_ns)
+        else file2
+    )
+    return reduce(reducer, files)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,15 +6,15 @@ from tempfile import TemporaryDirectory
 import pathlib
 
 
-class TestModel(model.Model):
+class BasicModel(model.Model):
     def __init__(self, *args, **kwargs):
-        super(TestModel, self).__init__(*args, **kwargs)
+        super(BasicModel, self).__init__(*args, **kwargs)
         self.dense = torch.nn.Linear(100, 20)
 
 
 def test_checkpoint_dir(tmp_path):
     # test that checkpoint directory is lazily created if it does not exist
-    model = TestModel(checkpoint_dir=f"{tmp_path}/checkpoints")
+    model = BasicModel(checkpoint_dir=f"{tmp_path}/checkpoints")
     assert not model.checkpoint_dir.exists()
     model.save("test.pth")
     assert model.checkpoint_dir.exists()
@@ -23,7 +23,7 @@ def test_checkpoint_dir(tmp_path):
 def test_checkpoint_dir_pathlib(tmp_path):
     # test that checkpoint directory is lazily created from pathlib.Path if it does not exist
     path = pathlib.Path(tmp_path)
-    model = TestModel(checkpoint_dir=path / "checkpoints")
+    model = BasicModel(checkpoint_dir=path / "checkpoints")
     assert not model.checkpoint_dir.exists()
     model.save("test.pth")
     assert model.checkpoint_dir.exists()
@@ -35,7 +35,7 @@ def test_checkpoint_clobber():
         tempdir_path = pathlib.Path(tempdir) / "checkpoints"
         tempfile = tempdir_path / "cool_beans.txt"
 
-        model = TestModel(checkpoint_dir=tempdir_path)
+        model = BasicModel(checkpoint_dir=tempdir_path)
         assert not model.checkpoint_dir.exists()
         tempdir_path.mkdir(parents=True)
         tempfile.touch()
@@ -46,7 +46,7 @@ def test_checkpoint_clobber():
 
 def test_checkpoint_dir_create_parents(tmp_path):
     # test that checkpoint directory, if not exists, is created with parents
-    model = TestModel(checkpoint_dir=f"{tmp_path}/cool_beans/checkpoints")
+    model = BasicModel(checkpoint_dir=f"{tmp_path}/cool_beans/checkpoints")
     model.save()
     assert model.checkpoint_dir.exists()
     assert model.checkpoint_dir.parent.exists()
@@ -55,7 +55,7 @@ def test_checkpoint_dir_create_parents(tmp_path):
 def test_save_custom_name(tmp_path):
     # test that model can be saved with custom name
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = TestModel(checkpoint_dir=tmpdir)
+    model = BasicModel(checkpoint_dir=tmpdir)
     model.save("test.pth")
 
     assert (tmpdir / "test.pth").exists()
@@ -64,7 +64,7 @@ def test_save_custom_name(tmp_path):
 def test_save_weird_name(tmp_path):
     # test that model can be saved with weird name
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = TestModel(checkpoint_dir=tmpdir)
+    model = BasicModel(checkpoint_dir=tmpdir)
     model.save("asd1291___203__203__23421__321")
     assert (tmpdir / "asd1291___203__203__23421__321").exists()
 
@@ -72,10 +72,10 @@ def test_save_weird_name(tmp_path):
 def test_load(tmp_path):
     # test that model can be loaded
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = TestModel(checkpoint_dir=tmpdir)
+    model = BasicModel(checkpoint_dir=tmpdir)
     model.save("test.pth")
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load(name="test.pth")
     assert checkpoint["name"] == "test.pth"
     assert torch.equal(
@@ -97,7 +97,7 @@ def test_load_nonfile(tmp_path):
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
     (tmpdir / "test_dir").mkdir(parents=True)
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     with pytest.raises(IsADirectoryError):
         new_model.load(name="test_dir")
 
@@ -108,7 +108,7 @@ def test_load_empty_file(tmp_path):
     tmpdir.mkdir(parents=True)
     (tmpdir / "bad_checkpoint").touch()
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     with pytest.raises(EOFError):
         new_model.load(name="bad_checkpoint")
 
@@ -118,7 +118,7 @@ def test_load_auto_empty_directory(tmp_path):
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
     tmpdir.mkdir(parents=True)
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     with pytest.raises(RuntimeError):
         new_model.load()
 
@@ -126,12 +126,12 @@ def test_load_auto_empty_directory(tmp_path):
 def test_load_auto(tmp_path):
     """Tests that auto-loading from a directory with multiple checkpoints succeeds."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = TestModel(checkpoint_dir=tmpdir)
+    model = BasicModel(checkpoint_dir=tmpdir)
     model.save("test.pth")
     time.sleep(1)  # force a different timestamp
     model.save("test2.pth")
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load()
     assert checkpoint["name"] == "test2.pth"
 
@@ -139,18 +139,18 @@ def test_load_auto(tmp_path):
 def test_load_auto_one_choice(tmp_path):
     """Tests that auto-loading from a directory with one checkpoint succeeds."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = TestModel(checkpoint_dir=tmpdir)
+    model = BasicModel(checkpoint_dir=tmpdir)
     model.save("test_only.pth")
 
-    new_model = TestModel(checkpoint_dir=tmpdir)
+    new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load()
     assert checkpoint["name"] == "test_only.pth"
 
 
 def test_model_print():
     """Tests that the model prints correctly."""
-    model = TestModel(checkpoint_dir="checkpoints")
-    target = """TestModel:
+    model = BasicModel(checkpoint_dir="checkpoints")
+    target = """BasicModel:
 ==================================================
 dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
 ==================================================
@@ -162,9 +162,9 @@ Trainable: 2020 parameters (100.00% trainable)
 
 def test_model_print_frozen():
     """Tests that the model prints correctly with frozen parameters."""
-    model = TestModel(checkpoint_dir="checkpoints")
+    model = BasicModel(checkpoint_dir="checkpoints")
     model.dense.requires_grad_ = False
-    target = """TestModel:
+    target = """BasicModel:
 ==================================================
 dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
 ==================================================

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,174 @@
+import pyro.model as model
+import pytest
+import time
+import torch
+from tempfile import TemporaryDirectory
+import pathlib
+
+
+class TestModel(model.Model):
+    def __init__(self, *args, **kwargs):
+        super(TestModel, self).__init__(*args, **kwargs)
+        self.dense = torch.nn.Linear(100, 20)
+
+
+def test_checkpoint_dir(tmp_path):
+    # test that checkpoint directory is lazily created if it does not exist
+    model = TestModel(checkpoint_dir=f"{tmp_path}/checkpoints")
+    assert not model.checkpoint_dir.exists()
+    model.save("test.pth")
+    assert model.checkpoint_dir.exists()
+
+
+def test_checkpoint_dir_pathlib(tmp_path):
+    # test that checkpoint directory is lazily created from pathlib.Path if it does not exist
+    path = pathlib.Path(tmp_path)
+    model = TestModel(checkpoint_dir=path / "checkpoints")
+    assert not model.checkpoint_dir.exists()
+    model.save("test.pth")
+    assert model.checkpoint_dir.exists()
+
+
+def test_checkpoint_clobber():
+    # test that checkpoint directory, if already exists, is not clobbered
+    with TemporaryDirectory("tempdir") as tempdir:
+        tempdir_path = pathlib.Path(tempdir) / "checkpoints"
+        tempfile = tempdir_path / "cool_beans.txt"
+
+        model = TestModel(checkpoint_dir=tempdir_path)
+        assert not model.checkpoint_dir.exists()
+        tempdir_path.mkdir(parents=True)
+        tempfile.touch()
+        assert tempfile.exists()
+        model.save("test.pth")
+        assert tempfile.exists()
+
+
+def test_checkpoint_dir_create_parents(tmp_path):
+    # test that checkpoint directory, if not exists, is created with parents
+    model = TestModel(checkpoint_dir=f"{tmp_path}/cool_beans/checkpoints")
+    model.save()
+    assert model.checkpoint_dir.exists()
+    assert model.checkpoint_dir.parent.exists()
+
+
+def test_save_custom_name(tmp_path):
+    # test that model can be saved with custom name
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    model = TestModel(checkpoint_dir=tmpdir)
+    model.save("test.pth")
+
+    assert (tmpdir / "test.pth").exists()
+
+
+def test_save_weird_name(tmp_path):
+    # test that model can be saved with weird name
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    model = TestModel(checkpoint_dir=tmpdir)
+    model.save("asd1291___203__203__23421__321")
+    assert (tmpdir / "asd1291___203__203__23421__321").exists()
+
+
+def test_load(tmp_path):
+    # test that model can be loaded
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    model = TestModel(checkpoint_dir=tmpdir)
+    model.save("test.pth")
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    checkpoint = new_model.load(name="test.pth")
+    assert checkpoint["name"] == "test.pth"
+    assert torch.equal(
+        checkpoint["state_dict"]["dense.weight"], model.state_dict()["dense.weight"]
+    )
+    assert torch.equal(
+        checkpoint["state_dict"]["dense.bias"], model.state_dict()["dense.bias"]
+    )
+    assert torch.equal(
+        new_model.state_dict()["dense.weight"], model.state_dict()["dense.weight"]
+    )
+    assert torch.equal(
+        new_model.state_dict()["dense.bias"], model.state_dict()["dense.bias"]
+    )
+
+
+def test_load_nonfile(tmp_path):
+    """Tests that loading a non-file checkpoint (directory) fails."""
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    (tmpdir / "test_dir").mkdir(parents=True)
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    with pytest.raises(IsADirectoryError):
+        new_model.load(name="test_dir")
+
+
+def test_load_empty_file(tmp_path):
+    """Tests that loading an empty file fails."""
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    tmpdir.mkdir(parents=True)
+    (tmpdir / "bad_checkpoint").touch()
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    with pytest.raises(EOFError):
+        new_model.load(name="bad_checkpoint")
+
+
+def test_load_auto_empty_directory(tmp_path):
+    """Tests that auto-loading from an empty directory fails."""
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    tmpdir.mkdir(parents=True)
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    with pytest.raises(RuntimeError):
+        new_model.load()
+
+
+def test_load_auto(tmp_path):
+    """Tests that auto-loading from a directory with multiple checkpoints succeeds."""
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    model = TestModel(checkpoint_dir=tmpdir)
+    model.save("test.pth")
+    time.sleep(1)  # force a different timestamp
+    model.save("test2.pth")
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    checkpoint = new_model.load()
+    assert checkpoint["name"] == "test2.pth"
+
+
+def test_load_auto_one_choice(tmp_path):
+    """Tests that auto-loading from a directory with one checkpoint succeeds."""
+    tmpdir = pathlib.Path(tmp_path) / "checkpoints"
+    model = TestModel(checkpoint_dir=tmpdir)
+    model.save("test_only.pth")
+
+    new_model = TestModel(checkpoint_dir=tmpdir)
+    checkpoint = new_model.load()
+    assert checkpoint["name"] == "test_only.pth"
+
+
+def test_model_print():
+    """Tests that the model prints correctly."""
+    model = TestModel(checkpoint_dir="checkpoints")
+    target = """TestModel:
+==================================================
+dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
+==================================================
+Total: 2020 parameters
+Trainable: 2020 parameters (100.00% trainable)
+=================================================="""
+    assert str(model) == target
+
+
+def test_model_print_frozen():
+    """Tests that the model prints correctly with frozen parameters."""
+    model = TestModel(checkpoint_dir="checkpoints")
+    model.dense.requires_grad_ = False
+    target = """TestModel:
+==================================================
+dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
+==================================================
+Total: 2020 parameters
+Trainable: 0 parameters (0.00% trainable)
+=================================================="""
+    assert str(model) == target


### PR DESCRIPTION
Basic model framework which supports:
- (More) semantically rich model summary
   - Prints individual submodules of `pyro.model.Model` along with parameter counts
   - Parameter counts distinguish between trainable parameters and frozen parameters
- Object-oriented model loading and saving
   - Can save models to a specific path in a checkpoint directory (given as a model parameter)
   - By default models are saved with the current timestamp (`"%m-%d-%y_%H-%M-%S.pth"`) using `strftime` syntax
   - Can load model from checkpoint directory based on name. If no name is given, then the most recently created checkpoint will attempt to be loaded (failing if the file is not an actual checkpoint or contains inappropriate model weights).

Further integration testing will be done.