### PR TITLE
Model cleanup

### DIFF
--- a/pyro/model.py
+++ b/pyro/model.py
@@ -120,11 +120,6 @@ class Model(torch.nn.Module):
         output.append(thick_separator)
 
         return "\n".join(output)
-
-    def __repr__(self):
-        return self.summary()
-
-
 # --- utils ---
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,49 +14,49 @@ class BasicModel(model.Model):
 
 def test_checkpoint_dir(tmp_path):
     # test that checkpoint directory is lazily created if it does not exist
-    model = BasicModel(checkpoint_dir=f"{tmp_path}/checkpoints")
-    assert not model.checkpoint_dir.exists()
-    model.save("test.pth")
-    assert model.checkpoint_dir.exists()
+    net = BasicModel(checkpoint_dir=f"{tmp_path}/checkpoints")
+    assert not net.checkpoint_dir.exists()
+    net.save("test.pth")
+    assert net.checkpoint_dir.exists()
 
 
 def test_checkpoint_dir_pathlib(tmp_path):
     # test that checkpoint directory is lazily created from pathlib.Path if it does not exist
     path = pathlib.Path(tmp_path)
-    model = BasicModel(checkpoint_dir=path / "checkpoints")
-    assert not model.checkpoint_dir.exists()
-    model.save("test.pth")
-    assert model.checkpoint_dir.exists()
+    net = BasicModel(checkpoint_dir=path / "checkpoints")
+    assert not net.checkpoint_dir.exists()
+    net.save("test.pth")
+    assert net.checkpoint_dir.exists()
 
 
 def test_checkpoint_clobber():
     # test that checkpoint directory, if already exists, is not clobbered
     with TemporaryDirectory("tempdir") as tempdir:
         tempdir_path = pathlib.Path(tempdir) / "checkpoints"
-        tempfile = tempdir_path / "cool_beans.txt"
+        file = tempdir_path / "cool_beans.txt"
 
-        model = BasicModel(checkpoint_dir=tempdir_path)
-        assert not model.checkpoint_dir.exists()
+        net = BasicModel(checkpoint_dir=tempdir_path)
+        assert not net.checkpoint_dir.exists()
         tempdir_path.mkdir(parents=True)
-        tempfile.touch()
-        assert tempfile.exists()
-        model.save("test.pth")
-        assert tempfile.exists()
+        file.touch()
+        assert file.exists()
+        net.save("test.pth")
+        assert file.exists()
 
 
 def test_checkpoint_dir_create_parents(tmp_path):
     # test that checkpoint directory, if not exists, is created with parents
-    model = BasicModel(checkpoint_dir=f"{tmp_path}/cool_beans/checkpoints")
-    model.save()
-    assert model.checkpoint_dir.exists()
-    assert model.checkpoint_dir.parent.exists()
+    net = BasicModel(checkpoint_dir=f"{tmp_path}/cool_beans/checkpoints")
+    net.save()
+    assert net.checkpoint_dir.exists()
+    assert net.checkpoint_dir.parent.exists()
 
 
 def test_save_custom_name(tmp_path):
     # test that model can be saved with custom name
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = BasicModel(checkpoint_dir=tmpdir)
-    model.save("test.pth")
+    net = BasicModel(checkpoint_dir=tmpdir)
+    net.save("test.pth")
 
     assert (tmpdir / "test.pth").exists()
 
@@ -64,35 +64,35 @@ def test_save_custom_name(tmp_path):
 def test_save_weird_name(tmp_path):
     # test that model can be saved with weird name
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = BasicModel(checkpoint_dir=tmpdir)
-    model.save("asd1291___203__203__23421__321")
+    net = BasicModel(checkpoint_dir=tmpdir)
+    net.save("asd1291___203__203__23421__321")
     assert (tmpdir / "asd1291___203__203__23421__321").exists()
 
 
 def test_load(tmp_path):
     # test that model can be loaded
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = BasicModel(checkpoint_dir=tmpdir)
-    model.save("test.pth")
+    net = BasicModel(checkpoint_dir=tmpdir)
+    net.save("test.pth")
 
     new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load(name="test.pth")
     assert checkpoint["name"] == "test.pth"
     assert torch.equal(
-        checkpoint["state_dict"]["dense.weight"], model.state_dict()["dense.weight"]
+        checkpoint["state_dict"]["dense.weight"], net.state_dict()["dense.weight"]
     )
     assert torch.equal(
-        checkpoint["state_dict"]["dense.bias"], model.state_dict()["dense.bias"]
+        checkpoint["state_dict"]["dense.bias"], net.state_dict()["dense.bias"]
     )
     assert torch.equal(
-        new_model.state_dict()["dense.weight"], model.state_dict()["dense.weight"]
+        new_model.state_dict()["dense.weight"], net.state_dict()["dense.weight"]
     )
     assert torch.equal(
-        new_model.state_dict()["dense.bias"], model.state_dict()["dense.bias"]
+        new_model.state_dict()["dense.bias"], net.state_dict()["dense.bias"]
     )
 
 
-def test_load_nonfile(tmp_path):
+def test_load_non_file(tmp_path):
     """Tests that loading a non-file checkpoint (directory) fails."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
     (tmpdir / "test_dir").mkdir(parents=True)
@@ -114,7 +114,7 @@ def test_load_empty_file(tmp_path):
 
 
 def test_load_auto_empty_directory(tmp_path):
-    """Tests that auto-loading from an empty directory fails."""
+    """Tests that automatic weight loading from an empty directory fails."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
     tmpdir.mkdir(parents=True)
 
@@ -124,12 +124,12 @@ def test_load_auto_empty_directory(tmp_path):
 
 
 def test_load_auto(tmp_path):
-    """Tests that auto-loading from a directory with multiple checkpoints succeeds."""
+    """Tests that automatic weight loading from a directory with multiple checkpoints succeeds."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = BasicModel(checkpoint_dir=tmpdir)
-    model.save("test.pth")
+    net = BasicModel(checkpoint_dir=tmpdir)
+    net.save("test.pth")
     time.sleep(1)  # force a different timestamp
-    model.save("test2.pth")
+    net.save("test2.pth")
 
     new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load()
@@ -137,10 +137,10 @@ def test_load_auto(tmp_path):
 
 
 def test_load_auto_one_choice(tmp_path):
-    """Tests that auto-loading from a directory with one checkpoint succeeds."""
+    """Tests that automatic weight loading from a directory with one checkpoint succeeds."""
     tmpdir = pathlib.Path(tmp_path) / "checkpoints"
-    model = BasicModel(checkpoint_dir=tmpdir)
-    model.save("test_only.pth")
+    net = BasicModel(checkpoint_dir=tmpdir)
+    net.save("test_only.pth")
 
     new_model = BasicModel(checkpoint_dir=tmpdir)
     checkpoint = new_model.load()
@@ -149,7 +149,7 @@ def test_load_auto_one_choice(tmp_path):
 
 def test_model_print():
     """Tests that the model prints correctly."""
-    model = BasicModel(checkpoint_dir="checkpoints")
+    net = BasicModel(checkpoint_dir="checkpoints")
     target = """BasicModel:
 ==================================================
 dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
@@ -157,13 +157,13 @@ dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
 Total: 2020 parameters
 Trainable: 2020 parameters (100.00% trainable)
 =================================================="""
-    assert str(model) == target
+    assert net.summary() == target
 
 
 def test_model_print_frozen():
     """Tests that the model prints correctly with frozen parameters."""
-    model = BasicModel(checkpoint_dir="checkpoints")
-    model.dense.requires_grad_ = False
+    net = BasicModel(checkpoint_dir="checkpoints")
+    net.dense.requires_grad_ = False
     target = """BasicModel:
 ==================================================
 dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
@@ -171,4 +171,4 @@ dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
 Total: 2020 parameters
 Trainable: 0 parameters (0.00% trainable)
 =================================================="""
-    assert str(model) == target
+    assert net.summary() == target


### PR DESCRIPTION
- Removed `__repr__` implementation from `Model` to differentiate printing model from summarizing model. This accommodates the use case where a user would like to just print the model without the verbose summary
- Refactored tests to fix nits (e.g. naming conventions, using PyTest fixtures)