### PR TITLE
Updated model summary to show module tree

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pytest torch
+          python -m pip install flake8 pytest torch pytest-mock
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/pyro/model.py
+++ b/pyro/model.py
@@ -1,11 +1,12 @@
-import os
 import pathlib
+import shutil
+import torch
+
 from dataclasses import dataclass
 from datetime import datetime
 from functools import reduce
+from os import PathLike
 from typing import Callable, Iterable, Union
-
-import torch
 
 
 class Model(torch.nn.Module):
@@ -16,7 +17,7 @@ class Model(torch.nn.Module):
     Note: Only top level modules should extend this class - all other submodules should defer to `torch.nn.Module`.
     """
 
-    def __init__(self, checkpoint_dir: Union[str, os.PathLike], *args, **kwargs):
+    def __init__(self, checkpoint_dir: Union[str, PathLike], *args, **kwargs):
         """
         Initialize the Model object.
 
@@ -194,7 +195,7 @@ def build_summarizer() -> Callable[[torch.nn.Module, Union[int, None]], str]:
 
         with_parameter_counts = [
             "\n".join(stack[::-1]),
-            "═" * os.get_terminal_size().columns,
+            "═" * shutil.get_terminal_size().columns,
             f"Total: {total_count.total} parameters",
             f"Trainable: {total_count.trainable} parameters ({percent_trainable:.2f}% trainable)",
         ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -178,15 +178,12 @@ def test_load_auto_one_choice(tmp_path):
 def test_model_summary(mocker):
     """Tests that the model is summarized correctly."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = BasicModel(checkpoint_dir="checkpoints")
-    target = """module (BasicModel) - 2020 parameters
+    target = """ (BasicModel) - 2020 parameters
 └── dense (Linear) - 2020 parameters
 ══════════════════════════════════════════════════
 Total: 2020 parameters
@@ -197,11 +194,8 @@ Trainable: 2020 parameters (100.00% trainable)"""
 def test_model_summary_frozen(mocker):
     """Tests that the model is summarized correctly with frozen parameters."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = BasicModel(checkpoint_dir="checkpoints")
@@ -209,7 +203,7 @@ def test_model_summary_frozen(mocker):
     net.dense.weight.requires_grad = False
     net.dense.bias.requires_grad = False
 
-    target = """module (BasicModel) - 2020 parameters
+    target = """ (BasicModel) - 2020 parameters
 └── dense (Linear) - 2020 parameters
 ══════════════════════════════════════════════════
 Total: 2020 parameters
@@ -220,15 +214,12 @@ Trainable: 0 parameters (0.00% trainable)"""
 def test_nested_model_summary_depth_0(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 0."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = NestedBasicModel(checkpoint_dir="checkpoints")
-    target = """module (NestedBasicModel) - 102942 parameters
+    target = """ (NestedBasicModel) - 102942 parameters
 ══════════════════════════════════════════════════
 Total: 102942 parameters
 Trainable: 102942 parameters (100.00% trainable)"""
@@ -238,15 +229,12 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary_depth_1(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 1."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = NestedBasicModel(checkpoint_dir="checkpoints")
-    target = """module (NestedBasicModel) - 102942 parameters
+    target = """ (NestedBasicModel) - 102942 parameters
 ├── features (Sequential) - 102936 parameters
 └── norm (BatchNorm2d) - 6 parameters
 ══════════════════════════════════════════════════
@@ -258,15 +246,12 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary_depth_2(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 2."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = NestedBasicModel(checkpoint_dir="checkpoints")
-    target = """module (NestedBasicModel) - 102942 parameters
+    target = """ (NestedBasicModel) - 102942 parameters
 ├── features (Sequential) - 102936 parameters
 │   ├── 0 (ConvBN) - 960 parameters
 │   ├── 1 (ConvBN) - 18624 parameters
@@ -282,15 +267,12 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary(mocker):
     """Tests that the model is summarized correctly with nested layers."""
     mocker.patch(
-        'os.get_terminal_size',
-        return_value=namedtuple(
-            "TerminalSize",
-            ["columns", "lines"]
-        )(50, 100)
+        "os.get_terminal_size",
+        return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
     net = NestedBasicModel(checkpoint_dir="checkpoints")
-    target = """module (NestedBasicModel) - 102942 parameters
+    target = """ (NestedBasicModel) - 102942 parameters
 ├── features (Sequential) - 102936 parameters
 │   ├── 0 (ConvBN) - 960 parameters
 │   │   ├── conv (Conv2d) - 896 parameters

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,15 +1,47 @@
+import os
+
 import pyro.model as model
 import pytest
 import time
 import torch
 from tempfile import TemporaryDirectory
 import pathlib
+from collections import namedtuple
 
 
 class BasicModel(model.Model):
     def __init__(self, *args, **kwargs):
         super(BasicModel, self).__init__(*args, **kwargs)
         self.dense = torch.nn.Linear(100, 20)
+
+
+class ConvBN(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, activation, *args, **kwargs):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(in_channels, out_channels, *args, **kwargs)
+        self.bn = torch.nn.BatchNorm2d(out_channels)
+        torch.nn.init.kaiming_normal_(self.conv.weight, nonlinearity=activation)
+        torch.nn.init.constant_(self.conv.bias, 0)
+
+    def forward(self, x):
+        return self.bn(self.conv(x))
+
+
+class NestedBasicModel(model.Model):
+    def __init__(self, *args, **kwargs):
+        super(NestedBasicModel, self).__init__(*args, **kwargs)
+        self.features = torch.nn.Sequential(
+            ConvBN(3, 32, activation="relu", kernel_size=3, padding=1),
+            ConvBN(32, 64, activation="relu", kernel_size=3, padding=1),
+            ConvBN(64, 128, activation="relu", kernel_size=3, padding=1),
+            ConvBN(128, 8, activation="relu", kernel_size=3, padding=1),
+        )
+        self.norm = torch.nn.BatchNorm2d(3)
+
+    def forward(self, x):
+        x = self.norm(x)
+        x = self.features(x)
+        return x
 
 
 @pytest.fixture()
@@ -31,19 +63,18 @@ def test_checkpoint_dir_pathlib(tmp_path, net):
     assert net.checkpoint_dir.exists()
 
 
-def test_checkpoint_clobber():
+def test_checkpoint_clobber(tmpdir):
     # test that checkpoint directory, if already exists, is not clobbered
-    with TemporaryDirectory("tempdir") as tempdir:
-        tempdir_path = pathlib.Path(tempdir) / "checkpoints"
-        file = tempdir_path / "cool_beans.txt"
+    tempdir_path = pathlib.Path(tmpdir) / "checkpoints"
+    file = tempdir_path / "cool_beans.txt"
 
-        net = BasicModel(checkpoint_dir=tempdir_path)
-        assert not net.checkpoint_dir.exists()
-        tempdir_path.mkdir(parents=True)
-        file.touch()
-        assert file.exists()
-        net.save("test.pth")
-        assert file.exists()
+    net = BasicModel(checkpoint_dir=tempdir_path)
+    assert not net.checkpoint_dir.exists()
+    tempdir_path.mkdir(parents=True)
+    file.touch()
+    assert file.exists()
+    net.save("test.pth")
+    assert file.exists()
 
 
 def test_checkpoint_dir_create_parents(tmp_path):
@@ -144,28 +175,137 @@ def test_load_auto_one_choice(tmp_path):
     assert checkpoint["name"] == "test_only.pth"
 
 
-def test_model_print():
-    """Tests that the model prints correctly."""
+def test_model_summary(mocker):
+    """Tests that the model is summarized correctly."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
     net = BasicModel(checkpoint_dir="checkpoints")
-    target = """BasicModel:
-==================================================
-dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
-==================================================
+    target = """module (BasicModel) - 2020 parameters
+└── dense (Linear) - 2020 parameters
+══════════════════════════════════════════════════
 Total: 2020 parameters
-Trainable: 2020 parameters (100.00% trainable)
-=================================================="""
+Trainable: 2020 parameters (100.00% trainable)"""
     assert net.summary() == target
 
 
-def test_model_print_frozen():
-    """Tests that the model prints correctly with frozen parameters."""
+def test_model_summary_frozen(mocker):
+    """Tests that the model is summarized correctly with frozen parameters."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
     net = BasicModel(checkpoint_dir="checkpoints")
-    net.dense.requires_grad_ = False
-    target = """BasicModel:
-==================================================
-dense: Linear(in_features=100, out_features=20, bias=True) - 2020 parameters
-==================================================
+
+    net.dense.weight.requires_grad = False
+    net.dense.bias.requires_grad = False
+
+    target = """module (BasicModel) - 2020 parameters
+└── dense (Linear) - 2020 parameters
+══════════════════════════════════════════════════
 Total: 2020 parameters
-Trainable: 0 parameters (0.00% trainable)
-=================================================="""
+Trainable: 0 parameters (0.00% trainable)"""
+    assert net.summary() == target
+
+
+def test_nested_model_summary_depth_0(mocker):
+    """Tests that the model is summarized correctly with nested layers up to depth 0."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
+    net = NestedBasicModel(checkpoint_dir="checkpoints")
+    target = """module (NestedBasicModel) - 102942 parameters
+══════════════════════════════════════════════════
+Total: 102942 parameters
+Trainable: 102942 parameters (100.00% trainable)"""
+    assert net.summary(max_depth=0) == target
+
+
+def test_nested_model_summary_depth_1(mocker):
+    """Tests that the model is summarized correctly with nested layers up to depth 1."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
+    net = NestedBasicModel(checkpoint_dir="checkpoints")
+    target = """module (NestedBasicModel) - 102942 parameters
+├── features (Sequential) - 102936 parameters
+└── norm (BatchNorm2d) - 6 parameters
+══════════════════════════════════════════════════
+Total: 102942 parameters
+Trainable: 102942 parameters (100.00% trainable)"""
+    assert net.summary(max_depth=1) == target
+
+
+def test_nested_model_summary_depth_2(mocker):
+    """Tests that the model is summarized correctly with nested layers up to depth 2."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
+    net = NestedBasicModel(checkpoint_dir="checkpoints")
+    target = """module (NestedBasicModel) - 102942 parameters
+├── features (Sequential) - 102936 parameters
+│   ├── 0 (ConvBN) - 960 parameters
+│   ├── 1 (ConvBN) - 18624 parameters
+│   ├── 2 (ConvBN) - 74112 parameters
+│   └── 3 (ConvBN) - 9240 parameters
+└── norm (BatchNorm2d) - 6 parameters
+══════════════════════════════════════════════════
+Total: 102942 parameters
+Trainable: 102942 parameters (100.00% trainable)"""
+    assert net.summary(max_depth=2) == target
+
+
+def test_nested_model_summary(mocker):
+    """Tests that the model is summarized correctly with nested layers."""
+    mocker.patch(
+        'os.get_terminal_size',
+        return_value=namedtuple(
+            "TerminalSize",
+            ["columns", "lines"]
+        )(50, 100)
+    )
+
+    net = NestedBasicModel(checkpoint_dir="checkpoints")
+    target = """module (NestedBasicModel) - 102942 parameters
+├── features (Sequential) - 102936 parameters
+│   ├── 0 (ConvBN) - 960 parameters
+│   │   ├── conv (Conv2d) - 896 parameters
+│   │   └── bn (BatchNorm2d) - 64 parameters
+│   ├── 1 (ConvBN) - 18624 parameters
+│   │   ├── conv (Conv2d) - 18496 parameters
+│   │   └── bn (BatchNorm2d) - 128 parameters
+│   ├── 2 (ConvBN) - 74112 parameters
+│   │   ├── conv (Conv2d) - 73856 parameters
+│   │   └── bn (BatchNorm2d) - 256 parameters
+│   └── 3 (ConvBN) - 9240 parameters
+│       ├── conv (Conv2d) - 9224 parameters
+│       └── bn (BatchNorm2d) - 16 parameters
+└── norm (BatchNorm2d) - 6 parameters
+══════════════════════════════════════════════════
+Total: 102942 parameters
+Trainable: 102942 parameters (100.00% trainable)"""
     assert net.summary() == target

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -194,7 +194,7 @@ def test_load_auto_one_choice(tmp_path):
 def test_model_summary(mocker):
     """Tests that the model is summarized correctly."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -210,7 +210,7 @@ Trainable: 2020 parameters (100.00% trainable)"""
 def test_model_summary_frozen(mocker):
     """Tests that the model is summarized correctly with frozen parameters."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -230,7 +230,7 @@ Trainable: 0 parameters (0.00% trainable)"""
 def test_nested_model_summary_depth_0(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 0."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -245,7 +245,7 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary_depth_1(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 1."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -262,7 +262,7 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary_depth_2(mocker):
     """Tests that the model is summarized correctly with nested layers up to depth 2."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -283,7 +283,7 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_nested_model_summary(mocker):
     """Tests that the model is summarized correctly with nested layers."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
 
@@ -312,7 +312,7 @@ Trainable: 102942 parameters (100.00% trainable)"""
 def test_model_summary_invalid_depth(mocker):
     """Tests that an invalid depth raises an error."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
     net = NestedBasicModel(checkpoint_dir="checkpoints")
@@ -323,7 +323,7 @@ def test_model_summary_invalid_depth(mocker):
 def test_model_summary_large_depth(mocker):
     """Tests that a large depth is equivalent to no depth."""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
     net = NestedBasicModel(checkpoint_dir="checkpoints")
@@ -333,7 +333,7 @@ def test_model_summary_large_depth(mocker):
 def test_model_empty(mocker):
     """Tests that summarizer doesn't error on empty model (with no submodules)"""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
     net = EmptyModel(checkpoint_dir="checkpoints")
@@ -347,7 +347,7 @@ Trainable: 0 parameters (0.00% trainable)"""
 def test_model_no_submodule(mocker):
     """Tests that summarizer doesn't error on model with parameters but with no submodules"""
     mocker.patch(
-        "os.get_terminal_size",
+        "shutil.get_terminal_size",
         return_value=namedtuple("TerminalSize", ["columns", "lines"])(50, 100),
     )
     net = EmptyModelWithParams(checkpoint_dir="checkpoints")


### PR DESCRIPTION
## TODOs

- [x] Add test cases on edge-case tree max depths (`max_level` less than 0, greater than module tree depth)
- [x] Profile runtime of summary to see if optimization of current design is necessary (use large `torchvision` models)

--------
Updated the model summary status to print a module tree (via classic postorder traversal). Used to show the hierarchy of modules in the case of custom submodules, which are common with custom PyTorch implementations of research models (for example, those found in `torchvision.models`).

Sample summary output can be found below:
```bash
 (NestedBasicModel) - 102942 parameters
├── features (Sequential) - 102936 parameters
│   ├── 0 (ConvBN) - 960 parameters
│   │   ├── conv (Conv2d) - 896 parameters
│   │   └── bn (BatchNorm2d) - 64 parameters
│   ├── 1 (ConvBN) - 18624 parameters
│   │   ├── conv (Conv2d) - 18496 parameters
│   │   └── bn (BatchNorm2d) - 128 parameters
│   ├── 2 (ConvBN) - 74112 parameters
│   │   ├── conv (Conv2d) - 73856 parameters
│   │   └── bn (BatchNorm2d) - 256 parameters
│   └── 3 (ConvBN) - 9240 parameters
│       ├── conv (Conv2d) - 9224 parameters
│       └── bn (BatchNorm2d) - 16 parameters
└── norm (BatchNorm2d) - 6 parameters
══════════════════════════════════════════════════
Total: 102942 parameters
Trainable: 102942 parameters (100.00% trainable)
```
This model summary can be controlled to limit the depth of the module tree, and in turn the amount of information shown. The output below is the model summary for the same model as above, but with `max_level = 1`.
```bash
 (NestedBasicModel) - 102942 parameters
├── features (Sequential) - 102936 parameters
└── norm (BatchNorm2d) - 6 parameters
══════════════════════════════════════════════════
Total: 102942 parameters
Trainable: 102942 parameters (100.00% trainable)
```